### PR TITLE
Fix image overflow inside of /packages/view/

### DIFF
--- a/bropkg/webroot/css/bro.css
+++ b/bropkg/webroot/css/bro.css
@@ -28,6 +28,9 @@ select.div-toggle {
   font-size: 14px;
   min-width: 0px;
 }
+.markdown-body img {
+  max-width: 100%;
+}
 .packagebox {
     border: 1px solid #ddd;
     border-radius: 3px;


### PR DESCRIPTION
Hi there,

I noticed an issue with image elements included from the markdown parsed from github README's was overflowing their parent div. A concrete example is visible [here in production](https://packages.zeek.org/packages/view/b0b3b94a-d1ed-11e9-88be-0a645a3f3086):

Also included here for posterity's sake.

![overflow-img](https://user-images.githubusercontent.com/1095794/64920397-93319d00-d7b7-11e9-922a-c8b8764b845b.png)


The fix just requires setting a max-width in the CSS.