### PR TITLE
Render relative links in README Markdown correctly when it comes from Github, plus some URL path cleanup

### DIFF
--- a/bropkg/src/Controller/PackagesController.php
+++ b/bropkg/src/Controller/PackagesController.php
@@ -57,11 +57,24 @@ class PackagesController extends AppController
      */
     public function view($id = null)
     {
-        // If no pakcage specified, simply list all packages.
+        // If no package specified, simply list all packages.
         if (is_null($id)) {
             return $this->redirect([
                 'controller' => 'Packages',
                 'action' => 'index'
+            ]);
+        }
+
+        // If there's noise at the end of the URL path (i.e., anything after the
+        // ID in "packages/view/<ID>"), redirect back to the view:
+        $path = parse_url($this->request->url, PHP_URL_PATH);
+        $parts = explode($id, $path);
+
+        if (count($parts) >= 2 && strlen($parts[1]) > 0) {
+            return $this->redirect([
+                'controller' => 'Packages',
+                'action' => 'view',
+                $id
             ]);
         }
 

--- a/bropkg/src/Controller/TagsController.php
+++ b/bropkg/src/Controller/TagsController.php
@@ -49,6 +49,19 @@ class TagsController extends AppController
             ]);
         } 
 
+        // If there's noise at the end of the URL path (i.e., anything after the
+        // ID in "tags/view/<ID>"), redirect back to the view:
+        $path = parse_url($this->request->url, PHP_URL_PATH);
+        $parts = explode($id, $path);
+
+        if (count($parts) >= 2 && strlen($parts[1]) > 0) {
+            return $this->redirect([
+                'controller' => 'Tags',
+                'action' => 'view',
+                $id
+            ]);
+        }
+
         $tag = $this->Tags->get($id, [
             'contain' => ['Metadatas']
         ]);

--- a/bropkg/src/Template/Packages/view.ctp
+++ b/bropkg/src/Template/Packages/view.ctp
@@ -84,7 +84,7 @@ function strClean($str) {
             <?php if (preg_match('/\.rst$/', $package->readme_name)): ?>
                 <?= $this->RstMarkup->transform($package->readme); ?>
             <?php else: ?>
-                <?= $this->Markdown->transform($package->readme); ?>
+                <?= $this->Markdown->transform($this->MarkdownCanonifier->transform($package->readme, $package->url)); ?>
             <?php endif; ?>
             </article>
         </div>

--- a/bropkg/src/View/Helper/MarkdownCanonifierHelper.php
+++ b/bropkg/src/View/Helper/MarkdownCanonifierHelper.php
@@ -1,0 +1,62 @@
+<?php
+namespace App\View\Helper;
+
+use Cake\View\Helper;
+
+/**
+ * Markdown canonifier
+ *
+ * This massages Markdown text to make the outcome suitable for rendering
+ * on our site. The expectation is that the output is again transformed
+ * by a markdown renderer -- see Template/Packages/view.ctp.
+ */
+class MarkdownCanonifierHelper extends Helper
+{
+  /**
+   * Canonify Markdown content.
+   *
+   * @param string $input Markdown to be parsed.
+   * @param string $url The package URL for this Markdown.
+   * @return bool|string
+   */
+  public function transform($input, $url)
+  {
+      if (!is_string($input)) {
+          return false;
+      }
+      if (strcasecmp(parse_url($url, PHP_URL_HOST), "github.com") == 0) {
+          /* The package resides on Github. Replace relative links with a Github
+           * blob reference into the source tree. Github does the same, with one
+           * difference: Github knows the default branch, which the blob
+           * reference requires. We do not know that branch, but Github
+           * redirects an unknown branch to the default one. So we assume
+           * "main", and hope for the redirect to work out if needed.
+           */
+          $input = preg_replace_callback(
+              '|\]\(([^)]*)\)|',
+              function ($matches) use ($url) {
+                  if (empty(parse_url($matches[1], PHP_URL_SCHEME))) {
+                      return "](" . $url . "/blob/main/" . $matches[1] . ")";
+                  }
+
+                  /* This already links to a URL: keep as-is. */
+                  return $matches[0];
+              },
+              $input
+          );
+      } else {
+          /* For other sites simply remove the link, keeping its anchor text. We
+           * don't know where to direct the link.
+           */
+          $input = preg_replace_callback(
+              '|\[([^\]]*)\]\([^)]*\)|',
+              function ($matches) {
+                  return $matches[1];
+              },
+              $input
+          );
+      }
+
+      return $input;
+  }
+}


### PR DESCRIPTION
Alright, I have no idea how "correct" any of this is for PHP's Cake framework, but:
* URLs with garbage after the package & tag views get redirected back to "clean" URLs
* We now correctly render README paths to Github — you can try [here](https://packages.zeek.org/packages/view/1c43296f-78de-11ec-ba82-0a598146b5c6).
* We strip links in READMEs when they're not from Github, just keeping their anchor text

This last part ignores #6 for the time being but should work correctly if and when those READMEs appear.

This is actually running now on packages.zeek.org, hopefully improving the disk-fill situation. :crossed_fingers: 

The site has a lot of problems — the whole PHP dependency thing is busted on the instance we're running the site on. The `composer` version installed is old and uses ridiculous amounts of memory during dependency resolution, while a newer version avoids that but then blows up in the actual package dependencies because we're installing one package from a version called "dev-master", which has moved on and no longer works with our Cake version. I tried a couple of things but couldn't figure it out (interestingly, this dependency management behaves almost like zkg's but fails when it would be damn handy to be able to specify a git commit has as version — hah!).

I've simply preserved the `vendor/` tree in the resulting installation, which seems to work since we're not changing anything at that level.

Really good motivation to get the new version of the site up and running!

Resolves #8.