### PR TITLE
PHP8 upgrade follow-ups

### DIFF
--- a/bropkg/config/app.default.php
+++ b/bropkg/config/app.default.php
@@ -95,9 +95,9 @@ return [
          * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
          * If you set 'className' => 'Null' core cache will be disabled.
          */
-        '_cake_core_' => [
+        '_cake_translations_' => [
             'className' => 'File',
-            'prefix' => 'myapp_cake_core_',
+            'prefix' => 'myapp_cake_translations_',
             'path' => CACHE . 'persistent/',
             'serialize' => true,
             'duration' => '+1 years',

--- a/bropkg/config/app.php
+++ b/bropkg/config/app.php
@@ -107,9 +107,9 @@ return [
          * Duration will be set to '+2 minutes' in bootstrap.php when debug = true
          * If you set 'className' => 'Null' core cache will be disabled.
          */
-        '_cake_core_' => [
+        '_cake_translations_' => [
             'className' => FileEngine::class,
-            'prefix' => 'myapp_cake_core_',
+            'prefix' => 'myapp_cake_translations_',
             'path' => CACHE . 'persistent' . DS,
             'serialize' => true,
             'duration' => '+1 years',

--- a/bropkg/config/bootstrap.php
+++ b/bropkg/config/bootstrap.php
@@ -102,7 +102,7 @@ if (file_exists(CONFIG . 'app_local.php')) {
  */
 if (Configure::read('debug')) {
     Configure::write('Cache._cake_model_.duration', '+2 minutes');
-    Configure::write('Cache._cake_core_.duration', '+2 minutes');
+    Configure::write('Cache._cake_translations_.duration', '+2 minutes');
     // disable router cache during development
     Configure::write('Cache._cake_routes_.duration', '+2 seconds');
 }

--- a/bropkg/src/View/Helper/MarkdownHelper.php
+++ b/bropkg/src/View/Helper/MarkdownHelper.php
@@ -41,25 +41,48 @@ class MarkdownHelper extends Helper
    */
   public function canonify($input, $url)
   {
+      // TODO: It'd really be better do this when parsing the package data instead
+      // of doing this every time we load the package page.
+
       if (!is_string($input)) {
           return false;
       }
       if (strcasecmp(parse_url($url, PHP_URL_HOST), "github.com") == 0) {
-          /* The package resides on Github. Replace relative links with a Github
-           * blob reference into the source tree. Github does the same, with one
-           * difference: Github knows the default branch, which the blob
-           * reference requires. We do not know that branch, but Github
-           * redirects an unknown branch to the default one. So we assume
-           * "main", and hope for the redirect to work out if needed.
+          /* If the url passed is to github.com, we want to rewrite the relative
+           * links so that they link to github. For images, we want to link to
+           * raw.githubcontent.com so it will load the actual image instead. Other
+           * links can be to the repo view. There isn't a good way to look up the
+           * MIME type for the paths, so just assume anything ending in .jpg or
+           * .png is an image, and anything else isn't.
            */
           $input = preg_replace_callback(
               '|\]\(([^)]*)\)|',
               function ($matches) use ($url) {
+                  // Check for whether the URL in this has a scheme on it, something
+                  // like https://. Anything without that, we can consider a relative
+                  // link.
                   if (empty(parse_url($matches[1], PHP_URL_SCHEME))) {
-                      return "](" . $url . "/blob/main/" . $matches[1] . ")";
+                      $url_path = parse_url($matches[1], PHP_URL_PATH);
+
+                      // Github markdown links can have descriptive text after the link itself,
+                      // separated by a space from the link. parse_url and path_info don't
+                      // know this and so they return the whole thing. Split off just the first
+                      // part as the extension.
+                      $extension = explode(" ", pathinfo($url_path, PATHINFO_EXTENSION))[0];
+
+                      if (strcasecmp($extension, "jpg") == 0 ||
+                          strcasecmp($extension, "jpeg") == 0 ||
+                          strcasecmp($extension, "png") == 0 ||
+                          strcasecmp($extension, "gif") == 0 ||
+                          strcasecmp($extension, "webp") == 0) {
+                          $url = preg_replace('|://github\.com/|', '://raw.githubusercontent.com/', $url);
+                          return "](" . $url . "/master/" . $matches[1] . ")";
+                      }
+
+                      return "](" . $url . "/blob/master/" . $matches[1] . ")";
                   }
 
-                  /* This already links to a URL: keep as-is. */
+                  /* This already links to an absolute URL: keep as-is. */
                   return $matches[0];
               },
               $input

--- a/bropkg/src/View/Helper/MarkdownHelper.php
+++ b/bropkg/src/View/Helper/MarkdownHelper.php
@@ -2,7 +2,12 @@
 namespace App\View\Helper;
 
 use Cake\View\Helper;
-use League\CommonMark\CommonMarkConverter;
+use League\CommonMark\Environment\Environment;
+use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
+use League\CommonMark\Extension\DefaultAttributes\DefaultAttributesExtension;
+use League\CommonMark\Extension\Table\Table;
+use League\CommonMark\Extension\Table\TableExtension;
+use League\CommonMark\MarkdownConverter;
 
 /**
  * Markdown Helper
@@ -28,7 +33,21 @@ class MarkdownHelper extends Helper
       if ( $this->_converter !== null ) {
          return $this->_converter;
       }
-      $this->_converter = new CommonMarkConverter();
+
+      $config = [
+          'default_attributes' => [
+              Table::class => [
+                  'class' => 'table table-bordered'
+              ],
+          ],
+      ];
+
+      $environment = new Environment($config);
+      $environment->addExtension(new CommonMarkCoreExtension());
+      $environment->addExtension(new TableExtension());
+      $environment->addExtension(new DefaultAttributesExtension());
+
+      $this->_converter = new MarkdownConverter($environment);
       return $this->_converter;
   }
 

--- a/docker/Dockerfile.php
+++ b/docker/Dockerfile.php
@@ -1,4 +1,4 @@
-FROM php:8.1.33-fpm AS base
+FROM php:8.4-fpm AS base
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -41,7 +41,7 @@ RUN pip3 install --no-cache-dir --break-system-packages 'bro-package-ci@git+http
 # We could use the composer image directly here but using the php
 # one guarantees we have the same version of php installed. Instead
 # we pull the composer script from one of their images into this one.
-FROM php:8.1.33-fpm AS build
+FROM php:8.4-fpm AS build
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
- Fix a repeated deprecation warning in debug.log related to the last-minute upgrade to Cake 5.4.
- Bump the PHP container to PHP 8.4. We moved up to 8.1.33 in the original upgrade, but it's going to be end of life in December. Upgrading to 8.4 doesn't change anything about the site, so it's safe to just upgrade the containers.
- The Markdown canonifier was rewriting relative links on Github to be absolute links, but this doesn't work for images since it's linking to the page in the repo and not to the actual content. Fix this so it rewrites the links to raw.gtihubusercontent.com instead, which is where the content lives.
- Fix markdown conversion of tables, which I hadn't noticed on a couple of packages. This also sets the Boostrap class on generated tables so they're styled correctly.