### PR TITLE
Fix some formatting/styling nits

### DIFF
--- a/bropkg/templates/Pages/home.php
+++ b/bropkg/templates/Pages/home.php
@@ -62,7 +62,7 @@ $this->assign('title', 'Home');
   <hr class="my-4"/>
 
   <div class="row">
-    <div class="offset-5">
+    <div class="text-center">
       <h3>
         <?= $this->Html->link('View List of ' . $packagecount . ' Packages',
           ['controller' => 'packages']) ?>
@@ -72,8 +72,8 @@ $this->assign('title', 'Home');
 
   <hr class="my-4"/>
 
-  <div class="row">
-    <div class="col-sm-3 offset-2">
+  <div class="row justify-content-center">
+    <div class="col-sm-3">
       <h4 class="text-center">Top Watched</h4>
       <?php
         if (!empty($topwatched)) {

--- a/bropkg/templates/Pages/home.php
+++ b/bropkg/templates/Pages/home.php
@@ -50,12 +50,9 @@ $this->assign('title', 'Home');
           example:
         </div>
       </div>
-    </div>
-  </div>
-
-  <div class="row">
-    <div class="col mt-4 mb-4">
-      <pre>zkg install zeek/ncsa/bro-doctor</pre>
+      <div class="my-4">
+        <code class="p-3">zkg install zeek/ncsa/bro-doctor</code>
+      </div>
     </div>
   </div>
 

--- a/bropkg/webroot/css/zeek.css
+++ b/bropkg/webroot/css/zeek.css
@@ -90,10 +90,15 @@ h1,h2,h3,h4,h5,h6 {
 }
 
 pre {
-    background-color: #FFF;
-    border: 1px solid #999;
-    box-shadow: rgba(0, 0, 0, 0.24) 1px 2px 4px 0px;
-    padding: 5px;
+    background-color: #F0F1F2;
+    padding: 1rem;
+    border-radius: 0.25rem;
+}
+
+code {
+    background-color: #F0F1F2;
+    padding: 0.25rem;
+    border-radius: 0.25rem;
 }
 
 /* This was part of Bootstrap 3.x but was replaced with an attribute


### PR DESCRIPTION
This does two things

1. Fixes the centering of the bottom section on the home page.

Before:
<img width="1152" height="324" alt="Screenshot 2025-09-29 at 2 55 51 PM" src="https://github.com/user-attachments/assets/3bed2a74-89d5-4e59-ac45-0566f4da3944" />

After:
<img width="1157" height="286" alt="Screenshot 2025-09-29 at 2 55 57 PM" src="https://github.com/user-attachments/assets/44056ff6-626b-4f6a-abc9-3aa5257b1cf3" />

2. Fixes the styling of `<pre>` and `<code>` blocks to be similar to how GitHub would format them, which I feel like most people would be more familiar with. This also removes the black border around `<pre>` blocks. That fixes the home page to not have that weird box that looks like a search field but actually isn't.

Before:
<img width="1106" height="238" alt="Screenshot 2025-09-29 at 2 58 37 PM" src="https://github.com/user-attachments/assets/36caf626-0413-4ddb-b2a3-829aa0a25440" />
<img width="1175" height="193" alt="Screenshot 2025-09-29 at 2 58 14 PM" src="https://github.com/user-attachments/assets/34b47a06-7a0d-4abc-816e-8155745a93a6" />

After:
<img width="1099" height="273" alt="Screenshot 2025-09-29 at 2 58 44 PM" src="https://github.com/user-attachments/assets/5e75de31-c569-42bc-931a-e720b56fe37f" />
<img width="1140" height="131" alt="Screenshot 2025-09-29 at 2 58 18 PM" src="https://github.com/user-attachments/assets/e18d356b-c9f6-431d-9f8b-7fc9db04a2b3" />